### PR TITLE
Fixed Maven syntax in POM

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>dk.via.sep4</groupId>
             <artifactId>data</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>dk.via.sep4</groupId>
             <artifactId>web</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>dk.via.sep4</groupId>
             <artifactId>lorawan</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/lorawan/pom.xml
+++ b/lorawan/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>dk.via.sep4</groupId>
             <artifactId>data</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>dk.via.sep4</groupId>
             <artifactId>data</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixed the syntax of the properties that were being used in the POM instead of the dependency versions from parent.version to project.parent.version. Maven suggests it's better so might as well