### PR TITLE
Fix Date parsing on retrival

### DIFF
--- a/data/src/main/java/dk/via/sep4/cloud/data/dto/SensorReading.java
+++ b/data/src/main/java/dk/via/sep4/cloud/data/dto/SensorReading.java
@@ -56,7 +56,7 @@ public class SensorReading {
 		DateTimeFormatter format = new DateTimeFormatterBuilder()
 				.appendPattern(pattern)
 				.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
-				.appendPattern("'Z'")
+				.appendLiteral("Z")
 				.toFormatter();
 		this.timeReceived = Timestamp.valueOf(LocalDateTime.parse(timeJson.getString("$date"), format));
 	}


### PR DESCRIPTION
Retrival from database was throwing exceptions over parsing miliseconds and the zoneId, should be all fixed and it should now parse correctly timestamps in UTC